### PR TITLE
fix: read messages from GitHub push commits

### DIFF
--- a/e2e/action.e2e.test.ts
+++ b/e2e/action.e2e.test.ts
@@ -144,7 +144,7 @@ describe('packaged action with local git repositories', () => {
     );
   });
 
-  it.skip('reads commit messages from real GitHub push payload objects (#122)', () => {
+  it('reads commit messages from real GitHub push payload objects (#122)', () => {
     const fixture = run({
       version: '1.2.3',
       commits: ['feat: add login'],

--- a/src/toolkit.ts
+++ b/src/toolkit.ts
@@ -2,9 +2,10 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as github from '@actions/github';
 import fs from 'fs/promises';
+import type { Commit } from './version';
 
 type Payload = {
-  commits?: string[];
+  commits?: Commit[];
 };
 
 const inputNames = [

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -180,6 +180,31 @@ describe('version', () => {
       });
     });
 
+    it('should read commit messages from GitHub push payload objects', () => {
+      const commits = [
+        { message: 'fix: did something' },
+        { message: 'feat: added user login' },
+      ];
+      const build = bumpBuild(commits, currentVersion);
+
+      expect(build).toEqual({
+        code: 10300,
+        name: '1.3.0',
+        version: {
+          major: 1,
+          minor: 3,
+          patch: 0,
+        },
+      });
+    });
+
+    it('should ignore malformed commit payload entries', () => {
+      const commits = [{ message: undefined }, { message: 42 }];
+      const build = bumpBuild(commits, currentVersion);
+
+      expect(build.name).toBe('1.2.4');
+    });
+
     it('should bump patch, and keep major & minor the same', () => {
       const commits: string[] = ['chore: did something'];
       const build = bumpBuild(commits, currentVersion);

--- a/src/version.ts
+++ b/src/version.ts
@@ -11,6 +11,8 @@ export type Build = {
   code: number;
 };
 
+export type Commit = string | { message?: unknown };
+
 const getCommitIntent = (message: string): string => {
   const [commitIntent] = message.toLowerCase().split(':');
 
@@ -87,11 +89,16 @@ export const getBuildFromVersion = (version: Version): Build => {
 };
 
 export const bumpBuild = (
-  commits: string[],
+  commits: Commit[],
   currentVersion: Version,
   buildNumber?: string | number,
 ): Build => {
-  const semanticCommits = commits.filter(isSemanticCommit);
+  const semanticCommits = commits
+    .map((commit) => (typeof commit === 'string' ? commit : commit.message))
+    .filter(
+      (message): message is string =>
+        typeof message === 'string' && isSemanticCommit(message),
+    );
   const isMajor = semanticCommits.some(isMajorBump);
 
   if (isMajor) {


### PR DESCRIPTION
## Summary
- accept GitHub push-event commit objects as well as legacy commit-message strings
- extract and validate each commit's message before semantic classification
- keep malformed payload entries on the existing patch-bump fallback
- enable the realistic E2E regression for issue #122

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand (53 passing)
- npm run test:e2e (8 passing)

Depends on #127 for the E2E harness. This PR targets next directly and will reduce to the fix commit after #127 merges.

Fixes #122